### PR TITLE
Исключить замену символа "+" в чатах

### DIFF
--- a/app/components/markdown/markdown.tsx
+++ b/app/components/markdown/markdown.tsx
@@ -601,7 +601,13 @@ const Markdown = ({
 
     const parser = useRef(new Parser({urlFilter, minimumHashtagLength})).current;
     const renderer = useMemo(createRenderer, [theme, textStyles]);
-    let ast = parser.parse(value.toString());
+    let str = value.toString();
+
+    if (str && str.indexOf('+') !== -1) {
+        str = str.replace(/\+/g, '＋');
+    }
+
+    let ast = parser.parse(str);
 
     ast = combineTextNodes(ast);
     ast = addListItemIndices(ast);

--- a/assets/base/config.json
+++ b/assets/base/config.json
@@ -1,6 +1,6 @@
 {
-    "DefaultServerUrl": "",
-    "DefaultServerName": "",
+    "DefaultServerUrl": "https://6e7b6c4.platrum.ru/",
+    "DefaultServerName": "Platrum",
     "TestServerUrl": "http://localhost:8065",
     "AutoSelectServerUrl": false,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "emoji-regex": "10.3.0",
         "expo": "51.0.14",
         "expo-application": "5.9.1",
-        "expo-crypto": "~13.0.2",
+        "expo-crypto": "13.0.2",
         "expo-device": "6.0.2",
         "expo-image": "1.12.12",
         "expo-linear-gradient": "13.0.2",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
